### PR TITLE
Update dispenser.ts

### DIFF
--- a/src/booth/dispenser.ts
+++ b/src/booth/dispenser.ts
@@ -85,6 +85,9 @@ export function createDispenser(
     const captchaUUIDQuery = await signedFetch(`https://${serverURL}/captcha`, {
       method: 'POST'
     })
+    
+    captchaUUIDQuery.text = "" + captchaUUIDQuery.text
+    
     const json = JSON.parse(captchaUUIDQuery.text)
     return json.data.uuid
   }


### PR DESCRIPTION
This change fixes the message displayed by visual studio code editor: "Argument of type 'string | undefined' is not assignable to parameter of type 'string'. Type 'undefined' is not assignable to type 'string'."